### PR TITLE
Merchant endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
-# README
+# Rails Engine
+This readme is a work in progress.
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+[Project Site](https://backend.turing.io/module3/projects/rails_engine/)
+[Technical Requirements](https://backend.turing.io/module3/projects/rails_engine/requirements)
+[Extensions](https://backend.turing.io/module3/projects/rails_engine/extensions)
+[Evaluation](https://backend.turing.io/module3/projects/rails_engine/evaluation)
 
-Things you may want to cover:
+## Overview
+Rails Engine is an API currently being developed in a simulated service-oriented architecture. Its purpose is to expose the data that powers an E-Commerce Application.
 
-* Ruby version
+This API is being created as a part of Turing School of Software & Design's back-end engineering program.
 
-* System dependencies
+## Setup
+clone, bundle, rake db:{create,migrate}, rake csv:reseed, bundle exec rspec
 
-* Configuration
+## Endpoints
 
-* Database creation
+### Accessing Endpoints
+rails s, localhost:3000 in URL of browser, navigate to desired URI
 
-* Database initialization
+### Merchant Endpoints
+```
+GET /api/v1/merchants
+GET /api/v1/merchants/:id
+PUT /api/v1/merchants
+PATCH /api/v1/merchants/:id
+DELETE /api/v1/merchants/:id
+```
 
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Business Intelligence Endpoints
+```
+GET /api
+```

--- a/app/controllers/api/v1/merchants/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants/merchants_controller.rb
@@ -6,4 +6,13 @@ class Api::V1::Merchants::MerchantsController < ApplicationController
   def show
     render json: MerchantSerializer.new(Merchant.find(params[:id]))
   end
+
+  def create
+    render json: MerchantSerializer.new(Merchant.create(merchant_params))
+  end
+
+  private
+    def merchant_params
+      params.require(:merchant).permit(:name)
+    end
 end

--- a/app/controllers/api/v1/merchants/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants/merchants_controller.rb
@@ -15,6 +15,10 @@ class Api::V1::Merchants::MerchantsController < ApplicationController
     render json: MerchantSerializer.new(Merchant.update(params[:id], merchant_params))
   end
 
+  def destroy
+    render json: MerchantSerializer.new(Merchant.destroy(params[:id]))
+  end
+
   private
     def merchant_params
       params.require(:merchant).permit(:name)

--- a/app/controllers/api/v1/merchants/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants/merchants_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::Merchants::MerchantsController < ApplicationController
   def index
     render json: MerchantSerializer.new(Merchant.all)
   end
+
+  def show
+    render json: MerchantSerializer.new(Merchant.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/merchants/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants/merchants_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::MerchantsController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Merchant.all)
+  end
+end

--- a/app/controllers/api/v1/merchants/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants/merchants_controller.rb
@@ -11,6 +11,10 @@ class Api::V1::Merchants::MerchantsController < ApplicationController
     render json: MerchantSerializer.new(Merchant.create(merchant_params))
   end
 
+  def update
+    render json: MerchantSerializer.new(Merchant.update(params[:id], merchant_params))
+  end
+
   private
     def merchant_params
       params.require(:merchant).permit(:name)

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,4 +1,4 @@
 class Customer < ApplicationRecord
   validates_presence_of :first_name, :last_name
-  has_many :invoices
+  has_many :invoices, dependent: :destroy
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -3,6 +3,6 @@ class Invoice < ApplicationRecord
   enum status: %w(shipped)
   belongs_to :customer
   belongs_to :merchant
-  has_many :invoice_items
-  has_many :transactions
+  has_many :invoice_items, dependent: :destroy
+  has_many :transactions, dependent: :destroy
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   validates_presence_of :name, :description, :unit_price
   belongs_to :merchant
-  has_many :invoice_items
+  has_many :invoice_items, dependent: :destroy
 
   before_create do
     self.unit_price /= 100.0

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,8 +1,8 @@
 class Merchant < ApplicationRecord
   validates_presence_of :name
-  has_many :invoices
+  has_many :invoices, dependent: :destroy
+  has_many :items, dependent: :destroy
   has_many :invoice_items, through: :invoices
-  has_many :items
   has_many :transactions, through: :invoices
 
   def self.most_revenue(amount)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       namespace :merchants do
         get '/', to: 'merchants#index'
         resources :most_revenue, only: [:index]
+        get '/:id', to: 'merchants#show'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         post '/', to: 'merchants#create'
         get '/:id', to: 'merchants#show'
         patch '/:id', to: 'merchants#update'
+        delete '/:id', to: 'merchants#destroy'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :merchants do
+        get '/', to: 'merchants#index'
         resources :most_revenue, only: [:index]
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :merchants do
         get '/', to: 'merchants#index'
+        post '/', to: 'merchants#create'
         resources :most_revenue, only: [:index]
         get '/:id', to: 'merchants#show'
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       namespace :merchants do
+        resources :most_revenue, only: [:index]
         get '/', to: 'merchants#index'
         post '/', to: 'merchants#create'
-        resources :most_revenue, only: [:index]
         get '/:id', to: 'merchants#show'
+        patch '/:id', to: 'merchants#update'
       end
     end
   end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -8,6 +8,11 @@
 
 ## Notes
 
+## Added Endpoints
+**Endpoints**
+```
+```
+
 ## RSpec Results
 **Models:**
 ```

--- a/spec/requests/api/v1/merchants/create_spec.rb
+++ b/spec/requests/api/v1/merchants/create_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Merchants API:' do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends back info of newly created merchant' do
+    post '/api/v1/merchants', params: {merchant: {name: 'Test Store'}}
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data']['id']).to eq('4')
+    expect(merchant['data']['type']).to eq('merchant')
+    expect(merchant['data']['attributes']['name']).to eq('Test Store')
+  end
+
+end

--- a/spec/requests/api/v1/merchants/destroy_spec.rb
+++ b/spec/requests/api/v1/merchants/destroy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Merchants API:' do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends the new info of a deleted merchant' do
+    expect(Merchant.count).to eq(3)
+    expect(Merchant.last.name).to eq('Ghost Shop')
+
+    delete '/api/v1/merchants/3'
+
+    deleted_merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(deleted_merchant['data']['id']).to eq('3')
+    expect(deleted_merchant['data']['attributes']['name']).to eq('Ghost Shop')
+    expect(Merchant.last.name).to_not eq('Ghost Shop')
+    expect{Merchant.find(3)}.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+end

--- a/spec/requests/api/v1/merchants/index_spec.rb
+++ b/spec/requests/api/v1/merchants/index_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'Merchants API:' do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends a list of all merchants' do
+    get '/api/v1/merchants'
+
+    merchants = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchants['data'].length).to eq(3)
+    expect(merchants['data'].first['id']).to eq('1')
+    expect(merchants['data'].second['id']).to eq('2')
+    expect(merchants['data'].third['id']).to eq('3')
+  end
+
+end

--- a/spec/requests/api/v1/merchants/most_revenue/index_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue/index_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-describe 'Merchants API' do
+describe 'Merchants API:' do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')
   end
 
-  it 'gets a list of merchants with the most revenue' do
+  it 'sends a list of merchants with the most revenue' do
     get '/api/v1/merchants/most_revenue?quantity=2'
 
     merchants = JSON.parse(response.body)

--- a/spec/requests/api/v1/merchants/show_spec.rb
+++ b/spec/requests/api/v1/merchants/show_spec.rb
@@ -12,8 +12,8 @@ describe 'Merchants API:' do
     merchant = JSON.parse(response.body)
 
     expect(response).to be_successful
-    expect(merchant['data'].length).to eq(1)
-    expect(merchant['data'].first['id']).to eq('3')
+    expect(merchant['data']['id']).to eq('3')
+    expect(merchant['data']['attributes']['name']).to eq('Ghost Shop')
   end
 
 end

--- a/spec/requests/api/v1/merchants/show_spec.rb
+++ b/spec/requests/api/v1/merchants/show_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Merchants API:' do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends one merchant by id' do
+    get '/api/v1/merchants/3'
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data'].length).to eq(1)
+    expect(merchant['data'].first['id']).to eq('3')
+  end
+
+end

--- a/spec/requests/api/v1/merchants/update_spec.rb
+++ b/spec/requests/api/v1/merchants/update_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'Merchants API:' do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends the new info of an updated merchant' do
+    patch '/api/v1/merchants/3', params: {merchant: {name: 'Superb Ghost Shop'}}
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data']['id']).to eq('3')
+    expect(merchant['data']['attributes']['name']).to eq('Superb Ghost Shop')
+    expect(Merchant.last.name).to eq('Superb Ghost Shop')
+  end
+
+end


### PR DESCRIPTION
## Description
Adds basic `Merchant` endpoints

## Type of change
- [ ] Bug fix
- [ ] Refactor
- [x] New feature
- [ ] Breaking change

## Notes
- Restructures request specs
  > `most_revenue_request_spec` renamed to `index_spec` and moved to `./spec/requests/api/v1/merchants/most_revenue/`
- Adds endpoints for merchants.
  > `create`, `destroy`, `index`, `show`, and `update`
- Updates PR template
  > space for added endpoints
- Updates readme
  > early WIP

## Added Endpoints
**Merchant Endpoints**
```
GET /api/v1/merchants
GET /api/v1/merchants/:id
PUT /api/v1/merchants
PATCH /api/v1/merchants/:id
DELETE /api/v1/merchants/:id
```

## RSpec Results
**Models:**
```
27 examples, 0 failures

Coverage report generated for RSpec - 190 / 190 LOC (100.0%) covered.
```

**Requests:**
```
6 examples, 0 failures

Coverage report generated for RSpec - 222 / 222 LOC (100.0%) covered.
```
