### PR TITLE
Item endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 This readme is a work in progress.
 
 [Project Site](https://backend.turing.io/module3/projects/rails_engine/)
+
 [Technical Requirements](https://backend.turing.io/module3/projects/rails_engine/requirements)
+
 [Extensions](https://backend.turing.io/module3/projects/rails_engine/extensions)
+
 [Evaluation](https://backend.turing.io/module3/projects/rails_engine/evaluation)
 
 ## Overview
 Rails Engine is an API currently being developed in a simulated service-oriented architecture. Its purpose is to expose the data that powers an E-Commerce Application.
 
-This API is being created as a part of Turing School of Software & Design's back-end engineering program.
+This API is being created as a part of [Turing School of Software & Design](https://turing.io/)'s [back-end engineering program](https://backend.turing.io/module3/).
 
 ## Setup
 clone, bundle, rake db:{create,migrate}, rake csv:reseed, bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ PATCH /api/v1/merchants/:id
 DELETE /api/v1/merchants/:id
 ```
 
+### Item Endpoints
+```
+GET /api/v1/items
+GET /api/v1/items/:id
+PUT /api/v1/items
+PATCH /api/v1/items/:id
+DELETE /api/v1/items/:id
+```
+
 ### Business Intelligence Endpoints
 ```
 GET /api

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -6,4 +6,13 @@ class Api::V1::Items::ItemsController < ApplicationController
   def show
     render json: ItemSerializer.new(Item.find(params[:id]))
   end
+
+  def create
+    render json: ItemSerializer.new(Item.create(item_params))
+  end
+
+  private
+    def item_params
+      params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+    end
 end

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -15,6 +15,10 @@ class Api::V1::Items::ItemsController < ApplicationController
     render json: ItemSerializer.new(Item.update(params[:id], item_params))
   end
 
+  def destroy
+    render json: ItemSerializer.new(Item.destroy(params[:id]))
+  end
+
   private
     def item_params
       params.require(:item).permit(:name, :description, :unit_price, :merchant_id)

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Items::ItemsController < ApplicationController
+  def index
+    render json: ItemSerializer.new(Item.all)
+  end
+end

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -11,6 +11,10 @@ class Api::V1::Items::ItemsController < ApplicationController
     render json: ItemSerializer.new(Item.create(item_params))
   end
 
+  def update
+    render json: ItemSerializer.new(Item.update(params[:id], item_params))
+  end
+
   private
     def item_params
       params.require(:item).permit(:name, :description, :unit_price, :merchant_id)

--- a/app/controllers/api/v1/items/items_controller.rb
+++ b/app/controllers/api/v1/items/items_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::Items::ItemsController < ApplicationController
   def index
     render json: ItemSerializer.new(Item.all)
   end
+
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -6,4 +6,8 @@ class InvoiceItem < ApplicationRecord
   before_create do
     self.unit_price /= 100.0
   end
+
+  before_update do
+    self.unit_price /= 100.0
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,7 +7,7 @@ class InvoiceItem < ApplicationRecord
     self.unit_price /= 100.0
   end
 
-  before_update do
-    self.unit_price /= 100.0
-  end
+  # before_update do
+  #   self.unit_price /= 100.0
+  # end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,8 @@ class Item < ApplicationRecord
   before_create do
     self.unit_price /= 100.0
   end
+
+  before_update do
+    self.unit_price /= 100.0
+  end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,6 @@
+class ItemSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :name, :description, :unit_price
+
+  belongs_to :merchant
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,10 @@ Rails.application.routes.draw do
         patch '/:id', to: 'merchants#update'
         delete '/:id', to: 'merchants#destroy'
       end
-      
+
       namespace :items do
         get '/', to: 'items#index'
+        get '/:id', to: 'items#show'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
         get '/', to: 'items#index'
         post '/', to: 'items#create'
         get '/:id', to: 'items#show'
+        patch '/:id', to: 'items#update'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
         post '/', to: 'items#create'
         get '/:id', to: 'items#show'
         patch '/:id', to: 'items#update'
+        delete '/:id', to: 'items#destroy'
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
       namespace :items do
         get '/', to: 'items#index'
+        post '/', to: 'items#create'
         get '/:id', to: 'items#show'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,10 @@ Rails.application.routes.draw do
         patch '/:id', to: 'merchants#update'
         delete '/:id', to: 'merchants#destroy'
       end
+      
+      namespace :items do
+        get '/', to: 'items#index'
+      end
     end
   end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :invoice_item do
     quantity { 14 }
     unit_price { 1.59 }
-    item { nil }
-    invoice { nil }
+    association :item
+    association :invoice
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :invoice do
     status { 0 }
-    customer { nil }
-    merchant { nil }
+    association :customer
+    association :merchant
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     name { "A Worldly Possession" }
     description { "You don't need to need one to buy one" }
     unit_price { 10.59 }
-    merchant { nil }
+    association :merchant
   end
 end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :transaction do
-    invoice { nil }
+    association :invoice
     credit_card_number { "4654405418249632" }
     credit_card_expiration_date { nil }
     result { 1 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,4 +11,17 @@ describe Item, type: :model do
     it { should have_many :invoice_items }
     it { should belong_to :merchant }
   end
+
+  describe 'callbacks' do
+    it 'convert price upon creation' do
+      item = create(:item, unit_price: 552)
+      expect(item.unit_price).to eq(5.52)
+    end
+
+    it 'convert price upon updating' do
+      item = create(:item, unit_price: 552)
+      item.update(unit_price: 123)
+      expect(item.unit_price).to eq(1.23)
+    end
+  end
 end

--- a/spec/requests/api/v1/items/create_spec.rb
+++ b/spec/requests/api/v1/items/create_spec.rb
@@ -7,7 +7,7 @@ describe 'Items API:', type: :request do
   end
 
   it 'sends back info of newly created item' do
-    item_params = {name: 'thing', description: 'buy it', unit_price: 2.5}
+    item_params = {name: 'thing', description: 'buy it', unit_price: 250, merchant_id: 3}
     post '/api/v1/items', params: {item: item_params}
 
     items = JSON.parse(response.body)
@@ -15,9 +15,9 @@ describe 'Items API:', type: :request do
     expect(response).to be_successful
     expect(items['data']['id']).to eq('17')
     expect(items['data']['type']).to eq('item')
-    expect(items['data']['attributes']['name']).to eq(params[:name])
-    expect(items['data']['attributes']['description']).to eq(params[:description])
-    expect(items['data']['attributes']['unit_price']).to eq(params[:unit_price])
+    expect(items['data']['attributes']['name']).to eq(item_params[:name])
+    expect(items['data']['attributes']['description']).to eq(item_params[:description])
+    expect(items['data']['attributes']['unit_price']).to eq(2.5)
   end
 
 end

--- a/spec/requests/api/v1/items/create_spec.rb
+++ b/spec/requests/api/v1/items/create_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends back info of newly created item' do
+    item_params = {name: 'thing', description: 'buy it', unit_price: 2.5}
+    post '/api/v1/items', params: {item: item_params}
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data']['id']).to eq('17')
+    expect(items['data']['type']).to eq('item')
+    expect(items['data']['attributes']['name']).to eq(params[:name])
+    expect(items['data']['attributes']['description']).to eq(params[:description])
+    expect(items['data']['attributes']['unit_price']).to eq(params[:unit_price])
+  end
+
+end

--- a/spec/requests/api/v1/items/destroy_spec.rb
+++ b/spec/requests/api/v1/items/destroy_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends the info of a deleted item' do
+    expect(Item.count).to eq(16)
+    expect(Item.fourth.name).to eq('Item Nemo Facere')
+
+    delete '/api/v1/items/4'
+
+    deleted_item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(deleted_item['data']['id']).to eq('4')
+    expect(deleted_item['data']['attributes']['name']).to eq('Item Nemo Facere')
+    expect(Item.count).to eq(15)
+    expect{Item.find(4)}.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+end

--- a/spec/requests/api/v1/items/index_spec.rb
+++ b/spec/requests/api/v1/items/index_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends a list of all items' do
+    get '/api/v1/items'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(16)
+    expect(items['data'].first['id']).to eq('1')
+    expect(items['data'].second['id']).to eq('2')
+    expect(items['data'].last['id']).to eq('16')
+  end
+
+end

--- a/spec/requests/api/v1/items/show_spec.rb
+++ b/spec/requests/api/v1/items/show_spec.rb
@@ -13,7 +13,7 @@ describe 'Items API:', type: :request do
     last = Item.last
 
     expect(response).to be_successful
-    expect(items['data']['id']).to eq(16)
+    expect(items['data']['id']).to eq('16')
     expect(items['data']['attributes']['name']).to eq(last.name)
     expect(items['data']['attributes']['description']).to eq(last.description)
     expect(items['data']['attributes']['unit_price']).to eq(last.unit_price)

--- a/spec/requests/api/v1/items/show_spec.rb
+++ b/spec/requests/api/v1/items/show_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends one items by id' do
+    get '/api/v1/items/16'
+
+    items = JSON.parse(response.body)
+    last = Item.last
+
+    expect(response).to be_successful
+    expect(items['data']['id']).to eq(16)
+    expect(items['data']['attributes']['name']).to eq(last.name)
+    expect(items['data']['attributes']['description']).to eq(last.description)
+    expect(items['data']['attributes']['unit_price']).to eq(last.unit_price)
+  end
+
+end

--- a/spec/requests/api/v1/items/update_spec.rb
+++ b/spec/requests/api/v1/items/update_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends the new info of an updated item' do
+    expect(Item.last.name).to eq('Item Ghost Magnam')
+    expect(Item.last.unit_price).to eq(123.45)
+
+    item_params = {name: 'Ghost Goods', unit_price: 25000}
+    old_description = Item.last.description
+    patch '/api/v1/items/16', params: {item: item_params}
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data']['id']).to eq('16')
+    expect(items['data']['attributes']['name']).to eq(item_params[:name])
+    expect(items['data']['attributes']['description']).to eq(old_description)
+    expect(items['data']['attributes']['unit_price']).to eq(250)
+
+    expect(Item.last.id).to eq(16)
+    expect(Item.last.name).to eq(item_params[:name])
+  end
+
+end

--- a/spec/requests/api/v1/merchants/create_spec.rb
+++ b/spec/requests/api/v1/merchants/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')

--- a/spec/requests/api/v1/merchants/destroy_spec.rb
+++ b/spec/requests/api/v1/merchants/destroy_spec.rb
@@ -18,6 +18,7 @@ describe 'Merchants API:', type: :request do
     expect(deleted_merchant['data']['id']).to eq('3')
     expect(deleted_merchant['data']['attributes']['name']).to eq('Ghost Shop')
     expect(Merchant.last.name).to_not eq('Ghost Shop')
+    expect(Merchant.count).to eq(2)
     expect{Merchant.find(3)}.to raise_error(ActiveRecord::RecordNotFound)
   end
 

--- a/spec/requests/api/v1/merchants/destroy_spec.rb
+++ b/spec/requests/api/v1/merchants/destroy_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')

--- a/spec/requests/api/v1/merchants/destroy_spec.rb
+++ b/spec/requests/api/v1/merchants/destroy_spec.rb
@@ -6,7 +6,7 @@ describe 'Merchants API:', type: :request do
     importer.reset_all_tables('./spec/fixtures/truncated/')
   end
 
-  it 'sends the new info of a deleted merchant' do
+  it 'sends the info of a deleted merchant' do
     expect(Merchant.count).to eq(3)
     expect(Merchant.last.name).to eq('Ghost Shop')
 

--- a/spec/requests/api/v1/merchants/index_spec.rb
+++ b/spec/requests/api/v1/merchants/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')

--- a/spec/requests/api/v1/merchants/most_revenue/index_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')

--- a/spec/requests/api/v1/merchants/show_spec.rb
+++ b/spec/requests/api/v1/merchants/show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')

--- a/spec/requests/api/v1/merchants/update_spec.rb
+++ b/spec/requests/api/v1/merchants/update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Merchants API:' do
+describe 'Merchants API:', type: :request do
   before(:each) do
     importer = Importer.new
     importer.reset_all_tables('./spec/fixtures/truncated/')


### PR DESCRIPTION
## Description
Adds basic `Item` endpoints

## Type of change
- [ ] Bug fix
- [ ] Refactor
- [x] New feature
- [ ] Breaking change

## Notes
- Adds endpoints for merchants.
  > `create`, `destroy`, `index`, `show`, and `update`

## Added Endpoints
**Item Endpoints**
```
GET /api/v1/items
GET /api/v1/items/:id
PUT /api/v1/items
PATCH /api/v1/items/:id
DELETE /api/v1/items/:id
```

## RSpec Results
**Models:**
```
29 examples, 0 failures

Coverage report generated for RSpec - 206 / 206 LOC (100.0%) covered.
```

**Requests:**
```
11 examples, 0 failures

Coverage report generated for RSpec - 322 / 322 LOC (100.0%) covered.
```
