### PR TITLE
Find endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ GET /api/v1/items/:id/merchant
 GET /api/v1/merchants/:id/items
 ```
 
+### Find Endpoints
+```
+GET /items/find?<attribute>=<value>
+GET /items/find_all?<attribute>=<value>
+GET /merchants/find?<attribute>=<value>
+GET /merchants/find_all?<attribute>=<value>
+```
+
 ### Business Intelligence Endpoints
 ```
 GET /api/v1/merchants/most_revenue?quantity=x

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::Items::SearchController < ApplicationController
+  def index
+    items = Item.search(request.query_parameters)
+    render json: ItemSerializer.new(items)
+  end
+
   def show
     item = Item.search(request.query_parameters).take
     render json: ItemSerializer.new(item)

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::SearchController < ApplicationController
+  def show
+    item = Item.search(request.query_parameters).take
+    render json: ItemSerializer.new(item)
+  end
+end

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Merchants::SearchController < ApplicationController
   def show
-    render json: MerchantSerializer.new(Merchant.search(request.query_parameters))
+    merchant = Merchant.search(request.query_parameters).take
+    render json: MerchantSerializer.new(merchant)
   end
 end

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::SearchController < ApplicationController
+  def show
+    render json: MerchantSerializer.new(Merchant.search(request.query_parameters))
+  end
+end

--- a/app/controllers/api/v1/merchants/search_controller.rb
+++ b/app/controllers/api/v1/merchants/search_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::Merchants::SearchController < ApplicationController
+  def index
+    merchant = Merchant.search(request.query_parameters)
+    render json: MerchantSerializer.new(merchant)
+  end
+
   def show
     merchant = Merchant.search(request.query_parameters).take
     render json: MerchantSerializer.new(merchant)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,4 +10,8 @@ class Item < ApplicationRecord
   before_update do
     self.unit_price /= 100.0
   end
+
+  def self.partial_matchables
+    ['name', 'description']
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,8 @@
+require './lib/modules/searchable'
+
 class Item < ApplicationRecord
+  include Searchable
+
   validates_presence_of :name, :description, :unit_price
   belongs_to :merchant
   has_many :invoice_items, dependent: :destroy

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,8 @@
+require './lib/modules/searchable'
+
 class Merchant < ApplicationRecord
+  include Searchable
+
   validates_presence_of :name
   has_many :invoices, dependent: :destroy
   has_many :items, dependent: :destroy
@@ -12,5 +16,9 @@ class Merchant < ApplicationRecord
       .group(:id)
       .order('revenue DESC')
       .limit(amount.to_i.abs)
+  end
+
+  def self.partial_matchables
+    ['name']
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :merchants do
         resources :most_revenue, only: [:index]
+        get '/find_all', to: 'search#index'
         get '/find', to: 'search#show'
         get '/', to: 'merchants#index'
         post '/', to: 'merchants#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       end
 
       namespace :items do
+        get '/find_all', to: 'search#index'
         get '/find', to: 'search#show'
         get '/', to: 'items#index'
         post '/', to: 'items#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       end
 
       namespace :items do
+        get '/find', to: 'search#show'
         get '/', to: 'items#index'
         post '/', to: 'items#create'
         get '/:id', to: 'items#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :merchants do
         resources :most_revenue, only: [:index]
+        get '/find', to: 'search#show'
         get '/', to: 'merchants#index'
         post '/', to: 'merchants#create'
         get '/:id', to: 'merchants#show'

--- a/lib/modules/searchable.rb
+++ b/lib/modules/searchable.rb
@@ -1,0 +1,21 @@
+module Searchable
+  def self.included(klass)
+    klass.extend ClassMethods
+  end
+
+  module ClassMethods
+    def search(query_params)
+      query_params.reduce(all) do |matches, (attribute, value)|
+        if partial_matchables.include?(attribute)
+          matches.partial_search(attribute, value)
+        else
+          matches.where(attribute.to_sym => value)
+        end
+      end
+    end
+
+    def partial_search(attribute, value)
+      where("#{attribute} ILIKE '%#{value}%'")
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,5 +34,26 @@ describe Item, type: :model do
     it 'partial_matchables' do
       expect(Item.partial_matchables).to eq(['name', 'description'])
     end
+
+    it 'search' do
+      search_params = {'unit_price' => '751.07', 'merchant_id' => '1'}
+
+      expect(Item.search(search_params)).to eq([Item.first])
+
+      expected = [3, 5, 7, 8, 12]
+      search_params = {'name' => 'Item E'}
+
+      expect(Item.search(search_params).pluck(:id)).to eq(expected)
+    end
+
+    it 'partial_search' do
+      search_params = {'name' => 'tem mi'}
+
+      expect(Item.search(search_params)).to eq([Item.second])
+
+      search_params = {'description' => 'lupTATe Aut Lab'}
+
+      expect(Item.search(search_params)).to eq([Item.fifth])
+    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -24,4 +24,15 @@ describe Item, type: :model do
       expect(item.unit_price).to eq(1.23)
     end
   end
+
+  describe 'methods' do
+    before(:each) do
+      importer = Importer.new
+      importer.reset_all_tables('./spec/fixtures/truncated/')
+    end
+
+    it 'partial_matchables' do
+      expect(Item.partial_matchables).to eq(['name', 'description'])
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -30,11 +30,13 @@ describe Merchant, type: :model do
 
     it 'search' do
       search_params = {'name' => 'Schroeder-Jerde', 'id' => '1'}
+
       expect(Merchant.search(search_params)).to eq([Merchant.first])
     end
 
     it 'partial_search' do
       search_params = {'name' => 'ghos'}
+      
       expect(Merchant.search(search_params)).to eq([Merchant.third])
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -27,5 +27,15 @@ describe Merchant, type: :model do
     it 'partial_matchables' do
       expect(Merchant.partial_matchables).to eq(['name'])
     end
+
+    it 'search' do
+      search_params = {'name' => 'Schroeder-Jerde', 'id' => '1'}
+      expect(Merchant.search(search_params)).to eq([Merchant.first])
+    end
+
+    it 'partial_search' do
+      search_params = {'name' => 'ghos'}
+      expect(Merchant.search(search_params)).to eq([Merchant.third])
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -23,5 +23,9 @@ describe Merchant, type: :model do
       expect(Merchant.most_revenue(2)).to eq([expected[0], expected[1]])
       expect(Merchant.most_revenue(1)).to eq([expected[0]])
     end
+
+    it 'partial_matchables' do
+      expect(Merchant.partial_matchables).to eq(['name'])
+    end
   end
 end

--- a/spec/requests/api/v1/items/search/index_spec.rb
+++ b/spec/requests/api/v1/items/search/index_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends a list of items by matched attribute' do
+    get '/api/v1/items/find_all?id=14'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(1)
+    expect(item_ids).to eq(['14'])
+
+    get '/api/v1/items/find_all?name=Expedita'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(2)
+    expect(item_ids).to eq(['5', '7'])
+
+    get '/api/v1/items/find_all?description=Sunt'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(5)
+    expect(item_ids).to eq(['3', '4', '5', '14', '16'])
+
+    get '/api/v1/items/find_all?unit_price=340.18'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(1)
+    expect(item_ids).to eq(['10'])
+
+    get '/api/v1/items/find_all?merchant_id=2'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(6)
+    expect(item_ids).to eq(['10', '11', '12', '13', '14', '15'])
+
+    get '/api/v1/items/find_all?created_at=2012-03-27 14:53:59'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(16)
+
+    get '/api/v1/items/find_all?updated_at=2012-03-27 14:53:59'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(16)
+  end
+
+  it 'sends a list of items by partially matched case insensitive attribute' do
+    get '/api/v1/items/find_all?name=expedita'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(2)
+    expect(item_ids).to eq(['5', '7'])
+
+    get '/api/v1/items/find_all?description=sunt'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(5)
+    expect(item_ids).to eq(['3', '4', '5', '14', '16'])
+  end
+
+  it 'sends a list of items by multiple matched attributes' do
+    get '/api/v1/items/find_all?description=sunt&name=magnam'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(1)
+    expect(items['data'].first['id']).to eq('16')
+
+    get '/api/v1/items/find_all?created_at=2012-03-27 14:53:59&description=fuga'
+
+    items = JSON.parse(response.body)
+    item_ids = items['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(items['data'].length).to eq(2)
+    expect(item_ids).to eq(['2', '7'])
+  end
+
+  it 'returns empty arrays for invalid searches' do
+    get '/api/v1/items/find_all?name=magnam&created_at=2012-03-27 14:53 UTC'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data']).to eq([])
+
+    get '/api/v1/items/find_all?name=Excellent'
+
+    items = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(items['data']).to eq([])
+  end
+
+end

--- a/spec/requests/api/v1/items/search/show_spec.rb
+++ b/spec/requests/api/v1/items/search/show_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe 'Items API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends one item by matched attribute' do
+    get '/api/v1/items/find?name=Ghost'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']['id']).to eq('16')
+    expect(item['data']['attributes']['name']).to eq('Item Ghost Magnam')
+  end
+
+  it 'sends one item by partially matched case insensitive attribute' do
+    get '/api/v1/items/find?name=ghos'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']['id']).to eq('16')
+    expect(item['data']['attributes']['name']).to eq('Item Ghost Magnam')
+
+    get '/api/v1/items/find?description=nostrum'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']['id']).to eq('13')
+    expect(item['data']['attributes']['name']).to eq('Item Voluptatem Sint')
+  end
+
+  it 'sends one item by multiple matched attributes' do
+    get '/api/v1/items/find?name=magnam&unit_price=123.45'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']['id']).to eq('16')
+    expect(item['data']['attributes']['name']).to eq('Item Ghost Magnam')
+
+    get '/api/v1/items/find?created_at=2012-03-27 14:53:59&name=item'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']['id']).to eq('1')
+    expect(item['data']['attributes']['name']).to eq('Item Qui Esse')
+  end
+
+  it 'returns nil for invalid searches' do
+    get '/api/v1/items/find?name=magnam&unit_price=123.4'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']).to eq(nil)
+
+    get '/api/v1/items/find?id=17'
+
+    item = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(item['data']).to eq(nil)
+  end
+
+end

--- a/spec/requests/api/v1/merchants/search/index_spec.rb
+++ b/spec/requests/api/v1/merchants/search/index_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Merchants API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends a list of merchants by matched name' do
+    get '/api/v1/merchants/find_all?name=p'
+
+    merchants = JSON.parse(response.body)
+    merchant_ids = merchants['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(merchants['data'].length).to eq(2)
+    expect(merchant_ids).to eq(['2', '3'])
+  end
+
+  it 'sends a list of merchants by partially matched case insensitive name' do
+    get '/api/v1/merchants/find_all?name=s'
+
+    merchants = JSON.parse(response.body)
+    merchant_ids = merchants['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(merchants['data'].length).to eq(3)
+    expect(merchant_ids).to eq(['1', '2', '3'])
+  end
+
+  it 'sends a list of merchants by multiple matched parameters' do
+    get '/api/v1/merchants/find_all?created_at=2012-03-27 14:53:59&name=h'
+
+    merchants = JSON.parse(response.body)
+    merchant_ids = merchants['data'].map { |hash| hash['id'] }
+
+    expect(response).to be_successful
+    expect(merchants['data'].length).to eq(2)
+    expect(merchant_ids).to eq(['1', '3'])
+  end
+
+end

--- a/spec/requests/api/v1/merchants/search/show_spec.rb
+++ b/spec/requests/api/v1/merchants/search/show_spec.rb
@@ -26,4 +26,14 @@ describe 'Merchants API:', type: :request do
     expect(merchant['data']['attributes']['name']).to eq('Schroeder-Jerde')
   end
 
+  it 'sends one merchant by multiple matched parameters' do
+    get '/api/v1/merchants/find?name=jerde&id=1'
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data']['id']).to eq('1')
+    expect(merchant['data']['attributes']['name']).to eq('Schroeder-Jerde')
+  end
+
 end

--- a/spec/requests/api/v1/merchants/search/show_spec.rb
+++ b/spec/requests/api/v1/merchants/search/show_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe 'Merchants API:', type: :request do
+  before(:each) do
+    importer = Importer.new
+    importer.reset_all_tables('./spec/fixtures/truncated/')
+  end
+
+  it 'sends one merchant by matched name' do
+    get '/api/v1/merchants/find?name=Ghost'
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data']['id']).to eq('3')
+    expect(merchant['data']['attributes']['name']).to eq('Ghost Shop')
+  end
+
+  it 'sends one merchant by partially matched case insensitive name' do
+    get '/api/v1/merchants/find?name=jerde'
+
+    merchant = JSON.parse(response.body)
+
+    expect(response).to be_successful
+    expect(merchant['data']['id']).to eq('1')
+    expect(merchant['data']['attributes']['name']).to eq('Schroeder-Jerde')
+  end
+
+end


### PR DESCRIPTION
## Description
Adds single finders and multi-finders for items and merchants

## Type of change
- [ ] Bug fix
- [ ] Refactor
- [x] New feature
- [ ] Breaking change

## Notes
Single finders use the same methods as the multi-finders but `take` the first match. The `take` is done at the controller level.

Adds `::partial_matchables` to `Item` and `Merchant` models
  - defines a list of attributes that are valid for partial case insensitive searches

Adds `Searchable` module
  - `::search` starts with all of a resource and reduces it with each query param
    - invokes `::partial_search` for attributes found in a model's `partial_matchables`
  - `::partial_search` is a partial, case insensitive query invoked for valid attributes

`/items/search/index_spec.rb` is currently the only spec that's fairly robust; other specs will be improved upon at a later time if time permits

## Added Endpoints
**Endpoints**
```
GET /items/find_all?<attribute>=<value>
GET /items/find?<attribute>=<value>
GET /merchants/find_all?<attribute>=<value>
GET /merchants/find?<attribute>=<value>
```

## RSpec Results
**Models:**
```
35 examples, 0 failures

Coverage report generated for RSpec - 256 / 256 LOC (100.0%) covered.
```

**Requests:**
```
27 examples, 0 failures

Coverage report generated for RSpec - 561 / 561 LOC (100.0%) covered.
```
